### PR TITLE
Remove dependency on running config_unix.py.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 MANIFEST
 Setup
+setup.cfg
 dist
 build
 build-stamp

--- a/README.md
+++ b/README.md
@@ -35,16 +35,12 @@ while 1:
 
 To build, you need the distutils package, availible from
 http://www.python.org/sigs/distutils-sig/download.html (it comes with
-Python 2.0). Run "python setup.py build" to build and then as root run
-"python setup.py install".  You may need to run the config_unix.py
-script, passing it a --prefix value if you've installed your mad stuff
-someplace weird.  Alternately, you can just create a file called
-"Setup" and put in values for mad_include_dir, mad_lib_dir, and
-mad_libs.  The file format for Setup is:
+Python 2.0). Run `python setup.py build` to build and then as root run
+`python setup.py install`.
 
-key = value
-
-with one pair per line.
+if you've installed your mad stuff someplace weird you may need to run
+the config_unix.py script, passing it a `--prefix` value to create a
+`setup.cfg` file with the correct include and link dirs:
 
 ```shell
 # python config_unix.py --prefix /usr/local
@@ -52,4 +48,12 @@ with one pair per line.
 # python setup.py install --prefix /usr/local
 ```
 
-Remember to make sure `/usr/local/python/site-packages/` is in your Python search path.
+Remember to make sure `/usr/local/python/site-packages/` is in your
+Python search path in that example.
+
+Alternately, you can write `setup.cfg` yourself. E.g.:
+
+    [build_ext]
+    library_dirs=/opt/mad/lib
+    include_dirs=/opt/mad/include
+    libraries=name_of_library_mad_might_depend_on

--- a/config_unix.py
+++ b/config_unix.py
@@ -45,11 +45,8 @@ int main ()
 def find_mad(mad_prefix='/usr/local', enable_madtest=1):
   """A rough translation of mad.m4"""
 
-  mad_libs = []
-
   mad_include_dir = mad_prefix + '/include'
   mad_lib_dir = mad_prefix + '/lib'
-  mad_libs = 'mad'
 
   msg_checking('for MAD')
 
@@ -68,17 +65,17 @@ def find_mad(mad_prefix='/usr/local', enable_madtest=1):
 
   print('success')
 
-  return {'mad_libs': mad_libs,
-          'mad_lib_dir': mad_lib_dir,
-          'mad_include_dir': mad_include_dir}
+  return {'library_dirs': mad_lib_dir,
+          'include_dirs': mad_include_dir}
 
 
 def write_data(data):
-  setup_file = open('Setup', 'w')
+  setup_file = open('setup.cfg', 'w')
+  setup_file.write('[build_ext]\n')
   for item in list(data.items()):
-    setup_file.write('%s = %s\n' % item)
+    setup_file.write('%s=%s\n' % item)
   setup_file.close()
-  print('Wrote Setup file')
+  print('Wrote setup.cfg file')
 
 
 def print_help():

--- a/setup.py
+++ b/setup.py
@@ -14,30 +14,6 @@ VERSION_MINOR = 9
 PYMAD_VERSION = str(VERSION_MAJOR) + '.' + str(VERSION_MINOR)
 
 
-def get_setup():
-  """Read the configuration data from the Setup file."""
-  data = {}
-  expr = re.compile(r'(\S+)\s*=\s*(.+)')
-
-  if not os.path.isfile('Setup'):
-    print("No 'Setup' file. Perhaps you need to run the configure script.")
-    sys.exit(1)
-
-  setup_file = open('Setup', 'r')
-
-  for line in setup_file.readlines():
-    match = expr.search(line)
-    if not match:
-      print('Error in setup file:', line)
-      sys.exit(1)
-    key = match.group(1)
-    val = match.group(2)
-    data[key] = val
-
-  return data
-
-SETUP_DATA = get_setup()
-
 DEFINES = [('VERSION_MAJOR', VERSION_MAJOR),
            ('VERSION_MINOR', VERSION_MINOR),
            ('VERSION', '"%s"' % PYMAD_VERSION)]
@@ -46,9 +22,7 @@ MADMODULE = Extension(
     name='mad',
     sources=['src/madmodule.c', 'src/pymadfile.c', 'src/xing.c'],
     define_macros=DEFINES,
-    include_dirs=[SETUP_DATA['mad_include_dir']],
-    library_dirs=[SETUP_DATA['mad_lib_dir']],
-    libraries=SETUP_DATA['mad_libs'].split())
+    libraries=['mad'])
 
 setup(  # Distribution metadata
     name='pymad',


### PR DESCRIPTION
pymad 0.9 cannot be installed with pip or as a setup.py dependency since it requires that config_unix.py is run before setup.py. On standard systems config_unix.py should not be needed at all.

This changes the behaviour of config_unix.py to write a standard setup.cfg file, so that it is no longer required to run it.  On nonstandard systems config_unix.py can still be used, or the user can manually write a setup.cfg file.